### PR TITLE
Remove YouTube video redirect, keep gif and lyrics

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -18,8 +18,6 @@ $(document).ready(function() {
             }, i * delay);
         });
 
-        setTimeout(function() {
-            window.location.href = 'https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=1&rel=0&start=43';
-        }, lines.length * delay + 1000);
+
     }
 })


### PR DESCRIPTION
Remove the setTimeout redirect to the YouTube embed URL so the page
stays on the gif background with animated lyrics instead of navigating
away.

https://claude.ai/code/session_01CkaevmThSKZsv2LKwaevs5